### PR TITLE
install_vs_code_ext: wrap `code` calls in `cmd /c` (fixes #1)

### DIFF
--- a/01_getting_set_up/install_vs_code_ext.bat
+++ b/01_getting_set_up/install_vs_code_ext.bat
@@ -1,0 +1,7 @@
+REM Install various Visual Studio Code extensions to make Python development easier.
+
+cmd /c "code --install-extension ms-vscode.atom-keybindings"
+cmd /c "code --install-extension ms-python.python"
+cmd /c "code --install-extension yzhang.markdown-all-in-one"
+cmd /c "code --install-extension njpwerner.autodocstring"
+cmd /c "code --install-extension redhat.vscode-xml"

--- a/01_getting_set_up/install_vs_code_ext.cmd
+++ b/01_getting_set_up/install_vs_code_ext.cmd
@@ -1,5 +1,0 @@
-code --install-extension ms-vscode.atom-keybindings
-code --install-extension ms-python.python
-code --install-extension yzhang.markdown-all-in-one
-code --install-extension njpwerner.autodocstring
-code --install-extension redhat.vscode-xml


### PR DESCRIPTION
Rename install_vs_code_ext.cmd to install_vs_code_ext.bat to make it a batch file. Wrap `code --install-extension` calls in `cmd /c` so that the batch file executes each call individually.